### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/judaicalink/docker/security/code-scanning/1](https://github.com/judaicalink/docker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the workflow's current functionality (checking out the repository and building a Docker image). This change ensures that the workflow does not inadvertently gain unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
