### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dockerhub:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/judaicalink/docker/security/code-scanning/3](https://github.com/judaicalink/docker/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's actions, it primarily interacts with DockerHub and does not require write access to the repository contents. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
